### PR TITLE
Bloquear cpf

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ Este sistema é responsável pela gestão de pagamentos e fraudes na plataforma 
 ## Features:
 
 :heavy_check_mark: Consulta de situação de um CPF
+
 :heavy_check_mark: Bloqueio de CPF
+
 :heavy_check_mark: Gestão dos meios de pagamentos
+
 :heavy_check_mark: Emitir cobranças
+
 :heavy_check_mark: Gestão de fraudes 
 
 ## Requisitos:

--- a/app/models/fraud_event.rb
+++ b/app/models/fraud_event.rb
@@ -1,2 +1,17 @@
 class FraudEvent < ApplicationRecord
+  after_save :block_cpf, if: :too_many_events?
+
+  private
+
+  def too_many_events?
+    frauds_count = FraudEvent.where(cpf: cpf).size
+    return false unless event_severity == 1 || frauds_count >= 3
+
+    true
+  end
+
+  def block_cpf
+    NegativeList.create(cpf: cpf,
+                        expiration_date: 1.year.from_now)
+  end
 end

--- a/app/models/fraud_event.rb
+++ b/app/models/fraud_event.rb
@@ -1,4 +1,5 @@
 class FraudEvent < ApplicationRecord
+  validate :validate_cpf
   after_save :block_cpf, if: :too_many_events?
 
   private
@@ -13,5 +14,11 @@ class FraudEvent < ApplicationRecord
   def block_cpf
     NegativeList.create(cpf: cpf,
                         expiration_date: 1.year.from_now)
+  end
+
+  def validate_cpf
+    return if Cpf.valid?(cpf)
+
+    errors.add :cpf, 'deve ser válido'
   end
 end

--- a/spec/factories/fraud_events.rb
+++ b/spec/factories/fraud_events.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :fraud_event do
-    cpf { '12345678900' }
+    cpf { '53282085796' }
     event_severity { 1 }
     description { 'Fraud Event' }
   end

--- a/spec/factories/fraud_events.rb
+++ b/spec/factories/fraud_events.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :fraud_event do
-    cpf { 'MyString' }
+    cpf { '12345678900' }
     event_severity { 1 }
+    description { 'Fraud Event' }
   end
 end

--- a/spec/models/cpf_spec.rb
+++ b/spec/models/cpf_spec.rb
@@ -9,28 +9,28 @@ RSpec.describe Cpf, type: :model do
     end
 
     it 'not blocking with two low occurrence' do
-      FraudEvent.create!(cpf: '12345678900', event_severity: 0, description: 'teste 1')
-      FraudEvent.create!(cpf: '12345678900', event_severity: 0, description: 'teste 2')
+      FraudEvent.create!(cpf: '53282085796', event_severity: 0, description: 'teste 1')
+      FraudEvent.create!(cpf: '53282085796', event_severity: 0, description: 'teste 2')
 
-      result = Cpf.qualify?('12345678900')
+      result = Cpf.qualify?('53282085796')
 
       expect(result).to eq false
     end
 
     it 'blocking with one high occurrence' do
-      FraudEvent.create!(cpf: '12345678900', event_severity: 1, description: 'teste 1')
+      FraudEvent.create!(cpf: '53282085796', event_severity: 1, description: 'teste 1')
 
-      result = Cpf.qualify?('12345678900')
+      result = Cpf.qualify?('53282085796')
 
       expect(result).to eq true
     end
 
     it 'blocking with three low occurrence' do
-      FraudEvent.create!(cpf: '12345678900', event_severity: 0, description: 'teste 1')
-      FraudEvent.create!(cpf: '12345678900', event_severity: 0, description: 'teste 2')
-      FraudEvent.create!(cpf: '12345678900', event_severity: 0, description: 'teste 3')
+      FraudEvent.create!(cpf: '53282085796', event_severity: 0, description: 'teste 1')
+      FraudEvent.create!(cpf: '53282085796', event_severity: 0, description: 'teste 2')
+      FraudEvent.create!(cpf: '53282085796', event_severity: 0, description: 'teste 3')
 
-      result = Cpf.qualify?('12345678900')
+      result = Cpf.qualify?('53282085796')
 
       expect(result).to eq true
     end

--- a/spec/models/fraud_event_spec.rb
+++ b/spec/models/fraud_event_spec.rb
@@ -21,5 +21,13 @@ RSpec.describe FraudEvent, type: :model do
 
       expect(NegativeList.blocked?('12345678900')).to be_falsy
     end
+
+    it 'should block for 12 months' do
+      FactoryBot.create(:fraud_event, { cpf: '12345678900', event_severity: 1 })
+      blocked_cpf = NegativeList.find_by(cpf: '12345678900')
+
+      expect(NegativeList.blocked?('12345678900')).to be_truthy
+      expect(blocked_cpf.expiration_date.to_s).to eq((Time.zone.today + 1.year).to_s)
+    end
   end
 end

--- a/spec/models/fraud_event_spec.rb
+++ b/spec/models/fraud_event_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FraudEvent, type: :model do
     end
 
     it 'with 3 low severity fraud events' do
-      3.times do 
+      3.times do
         FactoryBot.create(:fraud_event, { cpf: '12345678900', event_severity: 0 })
       end
 

--- a/spec/models/fraud_event_spec.rb
+++ b/spec/models/fraud_event_spec.rb
@@ -3,31 +3,39 @@ require 'rails_helper'
 RSpec.describe FraudEvent, type: :model do
   context 'Block CPF' do
     it 'with 1 high severity fraud event' do
-      FactoryBot.create(:fraud_event, { cpf: '12345678900', event_severity: 1 })
+      FactoryBot.create(:fraud_event, { cpf: '53282085796', event_severity: 1 })
 
-      expect(NegativeList.blocked?('12345678900')).to be_truthy
+      expect(NegativeList.blocked?('53282085796')).to be_truthy
     end
 
     it 'with 3 low severity fraud events' do
       3.times do
-        FactoryBot.create(:fraud_event, { cpf: '12345678900', event_severity: 0 })
+        FactoryBot.create(:fraud_event, { cpf: '53282085796', event_severity: 0 })
       end
 
-      expect(NegativeList.blocked?('12345678900')).to be_truthy
+      expect(NegativeList.blocked?('53282085796')).to be_truthy
     end
 
     it 'does not block if less than 3 low severity fraud events' do
-      FactoryBot.create(:fraud_event, { cpf: '12345678900', event_severity: 0 })
+      FactoryBot.create(:fraud_event, { cpf: '53282085796', event_severity: 0 })
 
-      expect(NegativeList.blocked?('12345678900')).to be_falsy
+      expect(NegativeList.blocked?('53282085796')).to be_falsy
     end
 
     it 'should block for 12 months' do
-      FactoryBot.create(:fraud_event, { cpf: '12345678900', event_severity: 1 })
-      blocked_cpf = NegativeList.find_by(cpf: '12345678900')
+      FactoryBot.create(:fraud_event, { cpf: '53282085796', event_severity: 1 })
+      blocked_cpf = NegativeList.find_by(cpf: '53282085796')
 
-      expect(NegativeList.blocked?('12345678900')).to be_truthy
+      expect(NegativeList.blocked?('53282085796')).to be_truthy
       expect(blocked_cpf.expiration_date.to_s).to eq((Time.zone.today + 1.year).to_s)
+    end
+
+    it 'only if cpf is valid' do
+      fraud_event = FraudEvent.new(cpf: '11111111111', event_severity: 1)
+
+      expect(fraud_event.valid?).to eq(false)
+      expect(fraud_event.errors.full_messages).to include('Cpf deve ser válido')
+      expect(fraud_event.errors.count).to eq(1)
     end
   end
 end

--- a/spec/models/fraud_event_spec.rb
+++ b/spec/models/fraud_event_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe FraudEvent, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'Block CPF' do
+    it 'with 1 high severity fraud event' do
+      FactoryBot.create(:fraud_event, { cpf: '12345678900', event_severity: 1 })
+
+      expect(NegativeList.blocked?('12345678900')).to be_truthy
+    end
+
+    it 'with 3 low severity fraud events' do
+      3.times do 
+        FactoryBot.create(:fraud_event, { cpf: '12345678900', event_severity: 0 })
+      end
+
+      expect(NegativeList.blocked?('12345678900')).to be_truthy
+    end
+
+    it 'does not block if less than 3 low severity fraud events' do
+      FactoryBot.create(:fraud_event, { cpf: '12345678900', event_severity: 0 })
+
+      expect(NegativeList.blocked?('12345678900')).to be_falsy
+    end
+  end
 end

--- a/spec/models/fraud_event_spec.rb
+++ b/spec/models/fraud_event_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FraudEvent, type: :model do
       blocked_cpf = NegativeList.find_by(cpf: '53282085796')
 
       expect(NegativeList.blocked?('53282085796')).to be_truthy
-      expect(blocked_cpf.expiration_date.to_s).to eq((Time.zone.today + 1.year).to_s)
+      expect(blocked_cpf.expiration_date.strftime('%F')).to eq(1.year.from_now.strftime('%F'))
     end
 
     it 'only if cpf is valid' do


### PR DESCRIPTION
Este pull request adiciona o bloqueio automático de CPF baseado nas ocorrências de Fraude.
Caso tenha 3 fraudes de nível baixo ou 1 fraude de nível alto, será adicionado à NegativeList. 
O bloqueio terá 12 meses.
[Trello: bloquear cpf](https://trello.com/c/9QZDDaMc)